### PR TITLE
mailreport: Add flag to allow skipping email send if there is no report content. Implements #11008

### DIFF
--- a/mail/pfSense-pkg-mailreport/Makefile
+++ b/mail/pfSense-pkg-mailreport/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pfSense-pkg-mailreport
-PORTVERSION=	3.5
+PORTVERSION=	3.5.1
 CATEGORIES=	mail
 MASTER_SITES=	# empty
 DISTFILES=	# empty

--- a/mail/pfSense-pkg-mailreport/files/usr/local/bin/mail_reports_generate.php
+++ b/mail/pfSense-pkg-mailreport/files/usr/local/bin/mail_reports_generate.php
@@ -62,12 +62,16 @@ if ((!is_array($cmds) || !(count($cmds) > 0))
 
 // Print report header
 
+// Used to determine if any content was generated
+$hascontent = 0;
+
 // Print command output
 $cmdtext = "";
 foreach ($cmds as $cmd) {
 	$output = "";
 	$cmdtext .= "Command output: {$cmd['descr']} (" . htmlspecialchars($cmd['detail']) . ")<br />\n";
 	exec($cmd['detail'], $output);
+	$hascontent = $hascontent + count($output);
 	$cmdtext .= "<pre>\n";
 	$cmdtext .= implode("\n", $output);
 	$cmdtext .= "\n</pre>";
@@ -80,10 +84,14 @@ foreach ($logs as $log) {
 	$filter = empty($log['detail']) ? null : array($log['detail']);
 	$logtext .= "Log output: " . get_friendly_log_name($log['logfile']) . " ({$log['logfile']})<br />\n";
 	$logtext .= "<pre>\n";
-	$logtext .= implode("\n", mail_report_get_log($log['logfile'], $lines, $filter));
+	$output = mail_report_get_log($log['logfile'], $lines, $filter);
+	$hascontent = $hascontent + count($output);
+	$logtext .= implode("\n", $output);
 	$logtext .= "\n</pre>";
 }
 
-mail_report_send($thisreport['descr'], $cmdtext, $logtext, $attach);
+if ($hascontent > 0 || empty($thisreport['skipifempty'])) {
+	mail_report_send($thisreport['descr'], $cmdtext, $logtext, $attach);
+}
 
 ?>

--- a/mail/pfSense-pkg-mailreport/files/usr/local/www/status_mail_report.php
+++ b/mail/pfSense-pkg-mailreport/files/usr/local/www/status_mail_report.php
@@ -91,6 +91,7 @@ include("head.inc");
 					<th>&nbsp;</th>
 					<th><?=gettext("Description")?></th>
 					<th><?=gettext("Schedule")?></th>
+					<th><?=gettext("Skippable")?></th>
 					<th><?=gettext("Commands")?></th>
 					<th><?=gettext("Logs")?></th>
 					<th><?=gettext("Actions")?></th>
@@ -111,6 +112,9 @@ include("head.inc");
 			</td>
 			<td onclick="fr_toggle(<?=$i?>)" id="frd<?=$i?>" ondblclick="document.location='status_mail_report_edit.php?id=<?=$i?>';">
 				<?=$mailreport['schedule_friendly']; ?>
+			</td>
+			<td onclick="fr_toggle(<?=$i?>)" id="frd<?=$i?>" ondblclick="document.location='status_mail_report_edit.php?id=<?=$i?>';">
+				<?=ucfirst($mailreport['skipifempty']); ?>
 			</td>
 			<td onclick="fr_toggle(<?=$i?>)" id="frd<?=$i?>" ondblclick="document.location='status_mail_report_edit.php?id=<?=$i?>';">
 				<?=(is_array($mailreport['cmd']['row']) ? count($mailreport['cmd']['row']) : 0); ?>

--- a/mail/pfSense-pkg-mailreport/files/usr/local/www/status_mail_report_edit.php
+++ b/mail/pfSense-pkg-mailreport/files/usr/local/www/status_mail_report_edit.php
@@ -241,6 +241,13 @@ $section->addInput(new Form_Input(
 	$pconfig['descr']
 ))->setHelp('Enter a description here for reference.');
 
+$section->addInput(new Form_Checkbox(
+	'skipifempty',
+	'Skip If No Content',
+	'Do not send the email if there is no content',
+	$pconfig['skipifempty']
+))->setHelp('If checked, no email will only be sent if there is output from the commands or content in the log files.');
+
 $form->add($section);
 
 $section = new Form_Section('Schedule');


### PR DESCRIPTION
Adds a flag to email report configs that will allow for the email to not be sent if there was no output from the commands or content in the log files.

https://redmine.pfsense.org/issues/11008